### PR TITLE
<#015> 종료 예정작 페이지 레이아웃 및 디자인

### DIFF
--- a/src/front-end/src/router/index.js
+++ b/src/front-end/src/router/index.js
@@ -18,6 +18,12 @@ const routes = [
 		name: 'Join',
 		component: () => import(/* webpackChunkName: "Join" */ '@/views/Join.vue'),
 	},
+	{
+		path: '/discontinue',
+		name: 'Discontinue',
+		component: () =>
+			import(/* webpackChunkName: "Join" */ '@/views/Discontinue.vue'),
+	},
 ];
 
 const router = createRouter({

--- a/src/front-end/src/views/Discontinue.vue
+++ b/src/front-end/src/views/Discontinue.vue
@@ -1,0 +1,90 @@
+<template>
+	<div class="discontinue">
+		<div class="row q-ma-lg">
+			<q-btn flat class="q-mt-lg q-mb-lg"> 7일 이내 종료 예정작</q-btn>
+			<q-btn flat class="q-mt-lg q-mb-lg"> 15일 이내 종료 예정작</q-btn>
+			<q-btn flat class="q-mt-lg q-mb-lg"> 30일 이내 종료 예정작</q-btn>
+		</div>
+		<div>
+			<q-infinite-scroll :offset="250" @load="videoOnLoad">
+				<div class="row q-ma-lg video-list-frame">
+					<div
+						class="video-poster"
+						v-for="(video, index) in videos"
+						:key="index">
+						<q-badge
+							class="row reverse q-ma-none q-pa-sm float-right bg-transparent badge-frame">
+							<q-avatar rounded color="grey" size="28px" class="q-ma-xs" />
+							<q-avatar rounded color="grey" size="28px" class="q-ma-xs" />
+						</q-badge>
+						{{ video.value }}
+					</div>
+				</div>
+				<template v-slot:loading>
+					<div class="row q-mb-lg justify-center">
+						<q-spinner-dots color="primary" size="40px" />
+					</div>
+				</template>
+			</q-infinite-scroll>
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'Discontinue',
+	data() {
+		return {
+			videos: [
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+			],
+		};
+	},
+	methods: {
+		videoOnLoad(index, done) {
+			setTimeout(() => {
+				this.videos.push({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {});
+				done();
+			}, 2000);
+		},
+	},
+};
+</script>
+
+<style scoped>
+.video-list-frame {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+}
+
+.video-poster {
+	width: 15%;
+	height: 0;
+	padding-bottom: 20%;
+	margin: 0 0 24px 0;
+	background: lightgrey;
+}
+
+.badge-frame {
+	display: flex;
+	flex-wrap: wrap;
+}
+</style>

--- a/src/front-end/src/views/Home.vue
+++ b/src/front-end/src/views/Home.vue
@@ -192,13 +192,10 @@
 			<q-btn flat>인기순</q-btn>
 		</div>
 		<!-- 작품 포스터 단락 -->
-		<q-infinite-scroll :offset="250" @load="posterOnLoad">
-			<div class="row q-ma-lg video-frame">
-				<div
-					class="video-poster"
-					v-for="(poster, index) in posters"
-					:key="index">
-					{{ poster }}
+		<q-infinite-scroll :offset="250" @load="videoOnLoad">
+			<div class="row q-ma-lg video-list-frame">
+				<div class="video-poster" v-for="(video, index) in videos" :key="index">
+					{{ video.value }}
 				</div>
 			</div>
 			<template v-slot:loading>
@@ -255,7 +252,7 @@ export default {
 				},
 			},
 			search: null,
-			posters: [
+			videos: [
 				{},
 				{},
 				{},
@@ -278,9 +275,9 @@ export default {
 		};
 	},
 	methods: {
-		posterOnLoad(index, done) {
+		videoOnLoad(index, done) {
 			setTimeout(() => {
-				this.posters.push({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {});
+				this.videos.push({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {});
 				done();
 			}, 2000);
 		},
@@ -292,7 +289,7 @@ export default {
 .ott-icons-frame {
 	column-gap: 16px;
 }
-.video-frame {
+.video-list-frame {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
@@ -303,6 +300,6 @@ export default {
 	height: 0;
 	padding-bottom: 20%;
 	margin: 0 0 24px 0;
-	background: grey;
+	background: lightgrey;
 }
 </style>


### PR DESCRIPTION
## 개요
- 종료 예정작 페이지 레이아웃 및 디자인

## 세부사항
- 버튼으로 남은 종료일 별 탭 구분
- 서비스 종료 예정인 ott 뱃지 가로 정렬
- 홈 페이지와 종료 예정작 페이지 클래스명 및 색상 통일 

## 참고
- Home.vue는 클래스 이름과 포스터 프레임 색상 통일하기 위해서 수정했어요!!
- router/index.js 에 종료 예정작 웹 주석 join으로 되어있는데 후에 라우팅하면서 수정할게요. 
- ott 로고 뱃지는 세로 정렬하면 수가 많을 때 포스터 밖으로 빠져나가서 가로 정렬했어요... 
 
## PR
- @yesslee 
