### PR TITLE
<#024> 내 정보 페이지 레이아웃 구현

### DIFF
--- a/src/front-end/src/router/index.js
+++ b/src/front-end/src/router/index.js
@@ -24,11 +24,18 @@ const routes = [
 		component: () =>
 			import(/* webpackChunkName: "Join" */ '@/views/Discontinue.vue'),
 	},
-  {
-    path: '/details',
+	{
+		path: '/details',
 		name: 'Details',
-		component: () => import(/* webpackChunkName: "Details" */ '@/views/Details.vue'),
-  },
+		component: () =>
+			import(/* webpackChunkName: "Details" */ '@/views/Details.vue'),
+	},
+	{
+		path: '/my',
+		name: 'My',
+		component: () =>
+			import(/* webpackChunkName: "My" */ '@/views/My.vue'),
+	},
 ];
 
 const router = createRouter({

--- a/src/front-end/src/styles/app.css
+++ b/src/front-end/src/styles/app.css
@@ -62,3 +62,7 @@
 .col-gap-16{
     column-gap: 16px;
 }
+
+.row-gap-12{
+    row-gap: 12px;
+}

--- a/src/front-end/src/views/My.vue
+++ b/src/front-end/src/views/My.vue
@@ -3,10 +3,10 @@
 	<div class="col q-mt-xl q-mb-xl q-ml-lg q-mr-lg profile-area">
 		<div class="row profile-info">
 			<q-avatar rounded color="blue" size="73px"></q-avatar>
-			<div class="col text-left profile-text">
+			<div class="col text-left row-gap-12">
 				<div class="q-mb-sm">사용자 닉네임</div>
 				<div>010-1234-5678</div>
-				<div class="row" style="column-gap: 12px">
+				<div class="row col-gap-12">
 					<!-- 가입시 이용한 카카오/네이버 API 아이콘 -->
 					<div class="api-icon"></div>
 					<div>naver_email@naver.com</div>
@@ -27,7 +27,7 @@
 				<q-avatar rounded color="blue" size="40px"></q-avatar>
 				<q-avatar rounded color="blue" size="40px"></q-avatar>
 			</div>
-			<div class="col text-left group-text">
+			<div class="col text-left row-gap-12">
 				<div>모집중 > 모집 완료 > 검토 기간 > 관람중</div>
 				<div>모집 상태 설명</div>
 				<div>추가 설명들</div>
@@ -99,7 +99,7 @@
 					v-model="ottPw">
 				</q-input>
 			</div>
-      <div class="row" style="column-gap: 12px;">
+      <div class="row col-gap-12">
         <q-space class="col-8" />
         <q-btn dense outline color="blue">
           <q-icon name="report" />
@@ -113,8 +113,9 @@
 	<q-separator color="blue" inset />
 	<!-- 최근 조회 작품 영역 -->
 	<div>최근 조회한 작품</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
+  <q-btn dense unelevated>전체보기</q-btn>
+  <div>영화 포스터</div>
+  <div>영화 포스터</div>
 	<div>영화 포스터</div>
 	<div>영화 포스터</div>
 	<div>영화 포스터</div>
@@ -169,9 +170,6 @@ export default {
 .profile-info {
 	column-gap: 24px;
 }
-.profile-text {
-	row-gap: 12px;
-}
 .api-icon {
 	width: 20px;
 	height: 20px;
@@ -179,9 +177,6 @@ export default {
 }
 .ott-icons-frame {
 	column-gap: 16px;
-}
-.group-text {
-	row-gap: 12px;
 }
 .state-badge {
 	width: auto;

--- a/src/front-end/src/views/My.vue
+++ b/src/front-end/src/views/My.vue
@@ -1,0 +1,33 @@
+<template>
+  <!-- 프로필 영역 -->
+  <div class="col q-mt-xl q-mb-xl q-ml-lg q-mr-lg profile-frame">
+    <div class="row profile-info">
+      <div class="profile-img">프로필 사진</div>
+      <div class="col text-left profile-text ">
+        <div class="q-mb-sm">사용자 닉네임</div>
+        <div>010-1234-5678</div>
+        <div class="row">
+          <!-- 로고는 가입시 이용한 카카오/네이버 API 아이콘 -->
+          <div class="api-logo q-mr-xs">로고</div>
+          <div>naver_email@naver.com</div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- hr -->
+  <q-separator color="blue" inset />
+</template>
+
+<style scoped>
+.profile-img {
+  width: 73px;
+  height: 73px;
+  background-color: #83BBFB;
+}
+.profile-info {
+  column-gap: 24px;
+}
+.profile-text {
+  row-gap: 12px;
+}
+</style>

--- a/src/front-end/src/views/My.vue
+++ b/src/front-end/src/views/My.vue
@@ -72,12 +72,12 @@
       <!-- 모임장: OTT 계정 ID/PW 입력 및 수정 가능 -->
 			<div class="col q-mt-md q-mb-md">
 				<q-input label="아이디" color="blue" class="ott-id" v-model="ottId">
-					<q-btn unelevated>
+					<q-btn dense unelevated>
 						<q-icon name="edit" color="blue" />
 					</q-btn>
 				</q-input>
 				<q-input label="비밀번호" color="blue" class="ott-pw" v-model="ottPw">
-					<q-btn unelevated>
+					<q-btn dense unelevated>
 						<q-icon name="edit" color="blue" />
 					</q-btn>
 				</q-input>

--- a/src/front-end/src/views/My.vue
+++ b/src/front-end/src/views/My.vue
@@ -1,33 +1,199 @@
 <template>
-  <!-- 프로필 영역 -->
-  <div class="col q-mt-xl q-mb-xl q-ml-lg q-mr-lg profile-frame">
-    <div class="row profile-info">
-      <div class="profile-img">프로필 사진</div>
-      <div class="col text-left profile-text ">
-        <div class="q-mb-sm">사용자 닉네임</div>
-        <div>010-1234-5678</div>
-        <div class="row">
-          <!-- 로고는 가입시 이용한 카카오/네이버 API 아이콘 -->
-          <div class="api-logo q-mr-xs">로고</div>
-          <div>naver_email@naver.com</div>
+	<!-- 프로필 영역 -->
+	<div class="col q-mt-xl q-mb-xl q-ml-lg q-mr-lg profile-area">
+		<div class="row profile-info">
+			<q-avatar rounded color="blue" size="73px"></q-avatar>
+			<div class="col text-left profile-text">
+				<div class="q-mb-sm">사용자 닉네임</div>
+				<div>010-1234-5678</div>
+				<div class="row" style="column-gap: 12px">
+					<!-- 가입시 이용한 카카오/네이버 API 아이콘 -->
+					<div class="api-icon"></div>
+					<div>naver_email@naver.com</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<!-- hr -->
+	<q-separator color="blue" inset />
+	<!-- 모임 관련 영역 -->
+	<div class="row q-mt-xl q-mb-xl q-ml-lg q-mr-lg">
+		<div class="col">
+			<div class="guide-text text-left q-mb-lg">참여 중인 모임</div>
+			<div class="row q-mb-md ott-icons-frame">
+				<q-avatar rounded color="blue" size="40px"></q-avatar>
+				<q-avatar rounded color="blue" size="40px"></q-avatar>
+				<q-avatar rounded color="blue" size="40px"></q-avatar>
+				<q-avatar rounded color="blue" size="40px"></q-avatar>
+				<q-avatar rounded color="blue" size="40px"></q-avatar>
+			</div>
+			<div class="col text-left group-text">
+				<div>모집중 > 모집 완료 > 검토 기간 > 관람중</div>
+				<div>모집 상태 설명</div>
+				<div>추가 설명들</div>
+				<div style="display: flex; flex-direction: row-reverse">
+          <q-btn dense unelevated>모임 탈퇴 하기 ></q-btn>
         </div>
       </div>
-    </div>
-  </div>
-  <!-- hr -->
-  <q-separator color="blue" inset />
+      <!-- 모임 구성원 관련 영역 -->
+      <div class="col group-members">
+        <div style="display: flex; flex-direction: row-reverse">
+          <q-badge
+            color="blue"
+            text-color="white"
+            align="top"
+            class="state-badge"
+            >모임 상태 설명</q-badge>
+        </div>
+        <div class="row q-pt-lg q-pb-xl group-profile-frame">
+          <q-space class="col-2" />
+          <div class="col group-nicknames">
+            <q-avatar rounded color="blue" size="73px" />
+            <div>사용자닉네임</div>
+          </div>
+          <div class="col group-nicknames">
+            <q-avatar rounded color="blue" size="73px" />
+            <div>
+              <q-icon name="military_tech" size="16px" />
+              닉네임
+            </div>
+          </div>
+          <div class="col group-nicknames">
+            <q-avatar rounded color="blue" size="73px" />
+            <div>닉네임</div>
+          </div>
+          <div class="col group-nicknames">
+            <q-avatar rounded color="blue" size="73px" />
+            <div>닉네임</div>
+          </div>
+          <q-space class="col-2" />
+        </div>
+      </div>
+      <!-- 모임장: OTT 계정 ID/PW 입력 및 수정 가능 -->
+			<div class="col q-mt-md q-mb-md">
+				<q-input label="아이디" color="blue" class="ott-id" v-model="ottId">
+					<q-btn unelevated>
+						<q-icon name="edit" color="blue" />
+					</q-btn>
+				</q-input>
+				<q-input label="비밀번호" color="blue" class="ott-pw" v-model="ottPw">
+					<q-btn unelevated>
+						<q-icon name="edit" color="blue" />
+					</q-btn>
+				</q-input>
+			</div>
+      <!-- 모임원: 모임장이 공유해 준 OTT 계정 ID/PW read only(드래그 & 복사 가능) -->
+			<div class="col q-mt-md q-mb-md">
+				<q-input
+					readonly
+					label="아이디"
+					color="blue"
+					class="ott-id"
+					v-model="ottId">
+				</q-input>
+				<q-input
+					readonly
+					label="비밀번호"
+					color="blue"
+					class="ott-pw"
+					v-model="ottPw">
+				</q-input>
+			</div>
+      <div class="row" style="column-gap: 12px;">
+        <q-space class="col-8" />
+        <q-btn dense outline color="blue">
+          <q-icon name="report" />
+          신고
+        </q-btn>
+        <q-btn dense outline color="blue">OTT 바로가기</q-btn>
+      </div>
+		</div>
+	</div>
+	<!-- hr -->
+	<q-separator color="blue" inset />
+	<!-- 최근 조회 작품 영역 -->
+	<div>최근 조회한 작품</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<!-- 본 작품 영역 -->
+	<div>본 작품</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<!-- 찜한 작품 영역 -->
+	<div>찜한 작품</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<!-- 별점 준 작품 -->
+	<div>별점 준 작품</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
+	<div>영화 포스터</div>
 </template>
 
+<script>
+export default {
+	name: 'My',
+	data() {
+		return {
+			ottId: 'netfilxID@gmail.com',
+			ottPw: 'netflix*Password',
+		};
+	},
+};
+</script>
+
 <style scoped>
-.profile-img {
-  width: 73px;
-  height: 73px;
-  background-color: #83BBFB;
-}
 .profile-info {
-  column-gap: 24px;
+	column-gap: 24px;
 }
 .profile-text {
-  row-gap: 12px;
+	row-gap: 12px;
+}
+.api-icon {
+	width: 20px;
+	height: 20px;
+	background-color: #828282;
+}
+.ott-icons-frame {
+	column-gap: 16px;
+}
+.group-text {
+	row-gap: 12px;
+}
+.state-badge {
+	width: auto;
+	height: 30px;
+}
+.group-members {
+	background-color: #e3f0ff;
+}
+.group-profile-frame {
+	column-gap: 24px;
+}
+.group-nicknames {
+	text-align: center;
 }
 </style>

--- a/src/front-end/src/views/My.vue
+++ b/src/front-end/src/views/My.vue
@@ -1,14 +1,14 @@
 <template>
 	<!-- 프로필 영역 -->
 	<div class="col q-mt-xl q-mb-xl q-ml-lg q-mr-lg profile-area">
-		<div class="row profile-info">
-			<q-avatar rounded color="blue" size="73px"></q-avatar>
+		<div class="row">
+			<q-avatar rounded color="blue" size="73px" class="q-mr-lg" />
 			<div class="col text-left row-gap-12">
 				<div class="q-mb-sm">사용자 닉네임</div>
 				<div>010-1234-5678</div>
 				<div class="row col-gap-12">
 					<!-- 가입시 이용한 카카오/네이버 API 아이콘 -->
-					<div class="api-icon"></div>
+					<div class="api-icon" />
 					<div>naver_email@naver.com</div>
 				</div>
 			</div>
@@ -31,45 +31,46 @@
 				<div>모집중 > 모집 완료 > 검토 기간 > 관람중</div>
 				<div>모집 상태 설명</div>
 				<div>추가 설명들</div>
-				<div style="display: flex; flex-direction: row-reverse">
-          <q-btn dense unelevated>모임 탈퇴 하기 ></q-btn>
-        </div>
-      </div>
-      <!-- 모임 구성원 관련 영역 -->
-      <div class="col group-members">
-        <div style="display: flex; flex-direction: row-reverse">
-          <q-badge
-            color="blue"
-            text-color="white"
-            align="top"
-            class="state-badge"
-            >모임 상태 설명</q-badge>
-        </div>
-        <div class="row q-pt-lg q-pb-xl group-profile-frame">
-          <q-space class="col-2" />
-          <div class="col group-nicknames">
-            <q-avatar rounded color="blue" size="73px" />
-            <div>사용자닉네임</div>
-          </div>
-          <div class="col group-nicknames">
-            <q-avatar rounded color="blue" size="73px" />
-            <div>
-              <q-icon name="military_tech" size="16px" />
-              닉네임
-            </div>
-          </div>
-          <div class="col group-nicknames">
-            <q-avatar rounded color="blue" size="73px" />
-            <div>닉네임</div>
-          </div>
-          <div class="col group-nicknames">
-            <q-avatar rounded color="blue" size="73px" />
-            <div>닉네임</div>
-          </div>
-          <q-space class="col-2" />
-        </div>
-      </div>
-      <!-- 모임장: OTT 계정 ID/PW 입력 및 수정 가능 -->
+				<div class="align-right">
+					<q-btn dense unelevated>모임 탈퇴 하기 ></q-btn>
+				</div>
+			</div>
+			<!-- 모임 구성원 관련 영역 -->
+			<div class="col group-members">
+				<div class="align-right">
+					<q-badge
+						color="blue"
+						text-color="white"
+						align="top"
+						class="state-badge"
+						>모임 상태 설명</q-badge
+					>
+				</div>
+				<div class="row q-pt-lg q-pb-xl group-profile-frame">
+					<q-space class="col-2" />
+					<div class="col group-nicknames">
+						<q-avatar rounded color="blue" size="73px" />
+						<div>사용자닉네임</div>
+					</div>
+					<div class="col group-nicknames">
+						<q-avatar rounded color="blue" size="73px" />
+						<div>
+							<q-icon name="military_tech" size="16px" />
+							닉네임
+						</div>
+					</div>
+					<div class="col group-nicknames">
+						<q-avatar rounded color="blue" size="73px" />
+						<div>닉네임</div>
+					</div>
+					<div class="col group-nicknames">
+						<q-avatar rounded color="blue" size="73px" />
+						<div>닉네임</div>
+					</div>
+					<q-space class="col-2" />
+				</div>
+			</div>
+			<!-- 모임장: OTT 계정 ID/PW 입력 및 수정 가능 -->
 			<div class="col q-mt-md q-mb-md">
 				<q-input label="아이디" color="blue" class="ott-id" v-model="ottId">
 					<q-btn dense unelevated>
@@ -82,7 +83,7 @@
 					</q-btn>
 				</q-input>
 			</div>
-      <!-- 모임원: 모임장이 공유해 준 OTT 계정 ID/PW read only(드래그 & 복사 가능) -->
+			<!-- 모임원: 모임장이 공유해 준 OTT 계정 ID/PW read only(드래그 & 복사 가능) -->
 			<div class="col q-mt-md q-mb-md">
 				<q-input
 					readonly
@@ -99,59 +100,80 @@
 					v-model="ottPw">
 				</q-input>
 			</div>
-      <div class="row col-gap-12">
-        <q-space class="col-8" />
-        <q-btn dense outline color="blue">
-          <q-icon name="report" />
-          신고
-        </q-btn>
-        <q-btn dense outline color="blue">OTT 바로가기</q-btn>
-      </div>
+			<div class="row col-gap-12">
+				<q-space class="col-8" />
+				<q-btn dense outline color="blue">
+					<q-icon name="report" />
+					신고
+				</q-btn>
+				<q-btn dense outline color="blue">OTT 바로가기</q-btn>
+			</div>
 		</div>
 	</div>
 	<!-- hr -->
 	<q-separator color="blue" inset />
 	<!-- 최근 조회 작품 영역 -->
-	<div>최근 조회한 작품</div>
-  <q-btn dense unelevated>전체보기</q-btn>
-  <div>영화 포스터</div>
-  <div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
+	<div class="col q-mt-xl q-mb-xl q-ml-lg q-mr-lg">
+		<div class="row">
+			<div class="q-mr-md">최근 조회한 작품</div>
+			<q-btn>전체보기</q-btn>
+		</div>
+		<q-virtual-scroll :items="videos" virtual-scroll-horizontal>
+			<div class="video-list-frame q-mt-lg q-mb-lg">
+				<div class="video-poster" v-for="(video, index) in videos" :key="index">
+					{{ video.value }}
+				</div>
+			</div>
+		</q-virtual-scroll>
+	</div>
+	<!-- hr -->
+	<q-separator color="blue" inset />
 	<!-- 본 작품 영역 -->
-	<div>본 작품</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
+	<div class="col q-mt-xl q-mb-xl q-ml-lg q-mr-lg">
+		<div class="row">
+			<div class="q-mr-md">본 작품</div>
+			<q-btn>전체보기</q-btn>
+		</div>
+		<q-virtual-scroll :items="videos" virtual-scroll-horizontal>
+			<div class="video-list-frame q-mt-lg q-mb-lg">
+				<div class="video-poster" v-for="(video, index) in videos" :key="index">
+					{{ video.value }}
+				</div>
+			</div>
+		</q-virtual-scroll>
+	</div>
+	<!-- hr -->
+	<q-separator color="blue" inset />
 	<!-- 찜한 작품 영역 -->
-	<div>찜한 작품</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
+	<div class="col q-mt-xl q-mb-xl q-ml-lg q-mr-lg">
+		<div class="row">
+			<div class="q-mr-md">찜한 작품</div>
+			<q-btn>전체보기</q-btn>
+		</div>
+		<q-virtual-scroll :items="videos" virtual-scroll-horizontal>
+			<div class="video-list-frame q-mt-lg q-mb-lg">
+				<div class="video-poster" v-for="(video, index) in videos" :key="index">
+					{{ video.value }}
+				</div>
+			</div>
+		</q-virtual-scroll>
+	</div>
+	<!-- hr -->
+	<q-separator color="blue" inset />
 	<!-- 별점 준 작품 -->
-	<div>별점 준 작품</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
-	<div>영화 포스터</div>
+	<div class="col q-mt-xl q-mb-xl q-ml-lg q-mr-lg">
+		<div class="row">
+			<div class="q-mr-md">별점 준 작품</div>
+			<q-btn>전체보기</q-btn>
+		</div>
+		<q-virtual-scroll :items="videos" virtual-scroll-horizontal>
+			<div class="video-list-frame q-mt-lg q-mb-lg">
+				<div class="video-poster" v-for="(video, index) in videos" :key="index">
+					{{ video.value }}
+				</div>
+			</div>
+		</q-virtual-scroll>
+	</div>
 </template>
 
 <script>
@@ -161,15 +183,13 @@ export default {
 		return {
 			ottId: 'netfilxID@gmail.com',
 			ottPw: 'netflix*Password',
+			videos: [{}, {}, {}],
 		};
 	},
 };
 </script>
 
 <style scoped>
-.profile-info {
-	column-gap: 24px;
-}
 .api-icon {
 	width: 20px;
 	height: 20px;
@@ -177,6 +197,10 @@ export default {
 }
 .ott-icons-frame {
 	column-gap: 16px;
+}
+.align-right {
+	display: flex;
+	flex-direction: row-reverse;
 }
 .state-badge {
 	width: auto;
@@ -190,5 +214,16 @@ export default {
 }
 .group-nicknames {
 	text-align: center;
+}
+.video-list-frame {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+}
+.video-poster {
+	width: 130px;
+	height: 180px;
+	margin-right: 24px;
+	background: lightgrey;
 }
 </style>

--- a/src/front-end/src/views/My.vue
+++ b/src/front-end/src/views/My.vue
@@ -118,51 +118,50 @@
 			<div class="q-mr-md">최근 조회한 작품</div>
 			<q-btn>전체보기</q-btn>
 		</div>
-    <div class="q-mt-lg">
-      <q-carousel
-          v-model="recent"
-          transition-prev="slide-right"
-          transition-next="slide-left"
-          swipeable
-          animated
-          control-color="primary"
-          padding
-          arrows
-          height="230px"
-          class="bg-blue-1"
-      >
-        <q-carousel-slide :name="1" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-        <q-carousel-slide :name="2" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-        <q-carousel-slide :name="3" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-      </q-carousel>
-    </div>
+		<div class="q-mt-lg">
+			<q-carousel
+				v-model="recent"
+				transition-prev="slide-right"
+				transition-next="slide-left"
+				swipeable
+				animated
+				control-color="primary"
+				padding
+				arrows
+				height="230px"
+				class="bg-blue-1">
+				<q-carousel-slide :name="1" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+				<q-carousel-slide :name="2" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+				<q-carousel-slide :name="3" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+			</q-carousel>
+		</div>
 	</div>
 	<!-- hr -->
 	<q-separator color="blue" inset />
@@ -172,51 +171,50 @@
 			<div class="q-mr-md">본 작품</div>
 			<q-btn>전체보기</q-btn>
 		</div>
-    <div class="q-mt-lg">
-      <q-carousel
-          v-model="watched"
-          transition-prev="slide-right"
-          transition-next="slide-left"
-          swipeable
-          animated
-          control-color="primary"
-          padding
-          arrows
-          height="230px"
-          class="bg-blue-1"
-      >
-        <q-carousel-slide :name="1" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-        <q-carousel-slide :name="2" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-        <q-carousel-slide :name="3" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-      </q-carousel>
-    </div>
+		<div class="q-mt-lg">
+			<q-carousel
+				v-model="watched"
+				transition-prev="slide-right"
+				transition-next="slide-left"
+				swipeable
+				animated
+				control-color="primary"
+				padding
+				arrows
+				height="230px"
+				class="bg-blue-1">
+				<q-carousel-slide :name="1" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+				<q-carousel-slide :name="2" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+				<q-carousel-slide :name="3" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+			</q-carousel>
+		</div>
 	</div>
 	<!-- hr -->
 	<q-separator color="blue" inset />
@@ -226,51 +224,50 @@
 			<div class="q-mr-md">찜한 작품</div>
 			<q-btn>전체보기</q-btn>
 		</div>
-    <div class="q-mt-lg">
-      <q-carousel
-          v-model="scrap"
-          transition-prev="slide-right"
-          transition-next="slide-left"
-          swipeable
-          animated
-          control-color="primary"
-          padding
-          arrows
-          height="230px"
-          class="bg-blue-1"
-      >
-        <q-carousel-slide :name="1" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-        <q-carousel-slide :name="2" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-        <q-carousel-slide :name="3" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-      </q-carousel>
-    </div>
+		<div class="q-mt-lg">
+			<q-carousel
+				v-model="scrap"
+				transition-prev="slide-right"
+				transition-next="slide-left"
+				swipeable
+				animated
+				control-color="primary"
+				padding
+				arrows
+				height="230px"
+				class="bg-blue-1">
+				<q-carousel-slide :name="1" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+				<q-carousel-slide :name="2" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+				<q-carousel-slide :name="3" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+			</q-carousel>
+		</div>
 	</div>
 	<!-- hr -->
 	<q-separator color="blue" inset />
@@ -280,51 +277,50 @@
 			<div class="q-mr-md">별점 준 작품</div>
 			<q-btn>전체보기</q-btn>
 		</div>
-    <div class="q-mt-lg">
-      <q-carousel
-          v-model="rated"
-          transition-prev="slide-right"
-          transition-next="slide-left"
-          swipeable
-          animated
-          control-color="primary"
-          padding
-          arrows
-          height="230px"
-          class="bg-blue-1"
-      >
-        <q-carousel-slide :name="1" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-        <q-carousel-slide :name="2" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-        <q-carousel-slide :name="3" class="column no-wrap">
-          <div class="row fit justify-center items-center col-gap-16 no-wrap">
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-            <div class="col-2 full-height video-poster" />
-          </div>
-        </q-carousel-slide>
-      </q-carousel>
-    </div>
+		<div class="q-mt-lg">
+			<q-carousel
+				v-model="rated"
+				transition-prev="slide-right"
+				transition-next="slide-left"
+				swipeable
+				animated
+				control-color="primary"
+				padding
+				arrows
+				height="230px"
+				class="bg-blue-1">
+				<q-carousel-slide :name="1" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+				<q-carousel-slide :name="2" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+				<q-carousel-slide :name="3" class="column no-wrap">
+					<div class="row fit justify-center items-center col-gap-16 no-wrap">
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+						<div class="col-2 full-height video-poster" />
+					</div>
+				</q-carousel-slide>
+			</q-carousel>
+		</div>
 	</div>
 </template>
 
@@ -335,10 +331,10 @@ export default {
 		return {
 			ottId: 'netfilxID@gmail.com',
 			ottPw: 'netflix*Password',
-      recent: 1,
-      watched: 1,
-      scrap: 1,
-      rated: 1,
+			recent: 1,
+			watched: 1,
+			scrap: 1,
+			rated: 1,
 		};
 	},
 };
@@ -373,6 +369,6 @@ export default {
 .video-poster {
 	width: 15%;
 	height: auto;
-	background: #83BBFB;
+	background: #83bbfb;
 }
 </style>

--- a/src/front-end/src/views/My.vue
+++ b/src/front-end/src/views/My.vue
@@ -118,13 +118,51 @@
 			<div class="q-mr-md">최근 조회한 작품</div>
 			<q-btn>전체보기</q-btn>
 		</div>
-		<q-virtual-scroll :items="videos" virtual-scroll-horizontal>
-			<div class="video-list-frame q-mt-lg q-mb-lg">
-				<div class="video-poster" v-for="(video, index) in videos" :key="index">
-					{{ video.value }}
-				</div>
-			</div>
-		</q-virtual-scroll>
+    <div class="q-mt-lg">
+      <q-carousel
+          v-model="recent"
+          transition-prev="slide-right"
+          transition-next="slide-left"
+          swipeable
+          animated
+          control-color="primary"
+          padding
+          arrows
+          height="230px"
+          class="bg-blue-1"
+      >
+        <q-carousel-slide :name="1" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide :name="2" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide :name="3" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+      </q-carousel>
+    </div>
 	</div>
 	<!-- hr -->
 	<q-separator color="blue" inset />
@@ -134,13 +172,51 @@
 			<div class="q-mr-md">본 작품</div>
 			<q-btn>전체보기</q-btn>
 		</div>
-		<q-virtual-scroll :items="videos" virtual-scroll-horizontal>
-			<div class="video-list-frame q-mt-lg q-mb-lg">
-				<div class="video-poster" v-for="(video, index) in videos" :key="index">
-					{{ video.value }}
-				</div>
-			</div>
-		</q-virtual-scroll>
+    <div class="q-mt-lg">
+      <q-carousel
+          v-model="watched"
+          transition-prev="slide-right"
+          transition-next="slide-left"
+          swipeable
+          animated
+          control-color="primary"
+          padding
+          arrows
+          height="230px"
+          class="bg-blue-1"
+      >
+        <q-carousel-slide :name="1" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide :name="2" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide :name="3" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+      </q-carousel>
+    </div>
 	</div>
 	<!-- hr -->
 	<q-separator color="blue" inset />
@@ -150,13 +226,51 @@
 			<div class="q-mr-md">찜한 작품</div>
 			<q-btn>전체보기</q-btn>
 		</div>
-		<q-virtual-scroll :items="videos" virtual-scroll-horizontal>
-			<div class="video-list-frame q-mt-lg q-mb-lg">
-				<div class="video-poster" v-for="(video, index) in videos" :key="index">
-					{{ video.value }}
-				</div>
-			</div>
-		</q-virtual-scroll>
+    <div class="q-mt-lg">
+      <q-carousel
+          v-model="scrap"
+          transition-prev="slide-right"
+          transition-next="slide-left"
+          swipeable
+          animated
+          control-color="primary"
+          padding
+          arrows
+          height="230px"
+          class="bg-blue-1"
+      >
+        <q-carousel-slide :name="1" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide :name="2" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide :name="3" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+      </q-carousel>
+    </div>
 	</div>
 	<!-- hr -->
 	<q-separator color="blue" inset />
@@ -166,13 +280,51 @@
 			<div class="q-mr-md">별점 준 작품</div>
 			<q-btn>전체보기</q-btn>
 		</div>
-		<q-virtual-scroll :items="videos" virtual-scroll-horizontal>
-			<div class="video-list-frame q-mt-lg q-mb-lg">
-				<div class="video-poster" v-for="(video, index) in videos" :key="index">
-					{{ video.value }}
-				</div>
-			</div>
-		</q-virtual-scroll>
+    <div class="q-mt-lg">
+      <q-carousel
+          v-model="rated"
+          transition-prev="slide-right"
+          transition-next="slide-left"
+          swipeable
+          animated
+          control-color="primary"
+          padding
+          arrows
+          height="230px"
+          class="bg-blue-1"
+      >
+        <q-carousel-slide :name="1" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide :name="2" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide :name="3" class="column no-wrap">
+          <div class="row fit justify-center items-center col-gap-16 no-wrap">
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+            <div class="col-2 full-height video-poster" />
+          </div>
+        </q-carousel-slide>
+      </q-carousel>
+    </div>
 	</div>
 </template>
 
@@ -183,7 +335,10 @@ export default {
 		return {
 			ottId: 'netfilxID@gmail.com',
 			ottPw: 'netflix*Password',
-			videos: [{}, {}, {}],
+      recent: 1,
+      watched: 1,
+      scrap: 1,
+      rated: 1,
 		};
 	},
 };
@@ -215,15 +370,9 @@ export default {
 .group-nicknames {
 	text-align: center;
 }
-.video-list-frame {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-between;
-}
 .video-poster {
-	width: 130px;
-	height: 180px;
-	margin-right: 24px;
-	background: lightgrey;
+	width: 15%;
+	height: auto;
+	background: #83BBFB;
 }
 </style>


### PR DESCRIPTION
## 개요
- 내 정보 페이지 레이아웃 구현

## 세부사항
- 모임 모집 상태 표시는 q-badge 이용
- 모임장/모임원에 따른 OTT 계정 수정 가능 여부 한 페이지 안에 구현해 둔 상태
- 모임장 표시용 왕관 아이콘 material Icon에 없어서 임의로 다른 아이콘 삽입

## 참고
- 모임 탈퇴하기, 모임 상태표시 뱃지 우측정렬 방식 - 좌측 space 잡는 방법 대신 flex로 해결
~~~
display: flex;
flex-direction: row-reverse;
~~~
- ~사용자 상호작용 작품 리스트 영역 가로 스크롤 q-virtual-scroll 이용(콘텐츠는 어설프게 넣어둔 상태입니다. 확인 후 수정 부탁드려요!)~
- 사용자 상호작용 작품 리스트 영역 virtual scroll에서 carousel로 변경
- 사용자 상호작용 작품 리스트 영역에서의 버튼은 일부러 기본 옵션으로 두었습니다.

## PR
- @a-sung 
