### PR TITLE
<#112> 프로필사진 업로드 API 구현

### DIFF
--- a/src/back-end/web/users/serializers.py
+++ b/src/back-end/web/users/serializers.py
@@ -127,3 +127,20 @@ class NicknameSerializer(serializers.ModelSerializer):
                 "validators": get_nickname_validators() + [get_unique_nickname_validator(User.objects.all())],
             },
         }
+
+
+class ProfileImageSerializer(serializers.ModelSerializer):
+    """User's profile image serializer"""
+
+    profile = serializers.URLField(source="profile_image_url")
+
+    class Meta:
+        """Metadata of ProfileImageSerializer"""
+
+        model = User
+        fields = ["profile"]
+        extra_kwargs = {
+            "profile": {
+                "required": True,
+            }
+        }

--- a/src/back-end/web/users/urls.py
+++ b/src/back-end/web/users/urls.py
@@ -5,7 +5,7 @@ from users.views import (
     GeneralLogoutView,
     GoogleLoginView,
     NaverLoginView,
-    ProfileImageCreateView,
+    ProfileImageUploadView,
     RefreshTokenView,
     SignUpView,
     UserWithdrawalView,
@@ -27,8 +27,8 @@ urlpatterns = [
     path("logout/", GeneralLogoutView.as_view(), name="logout"),
     # validate user fields
     path("validate-nickname/", ValidateNicknameView.as_view(), name="users_validate_nickname"),
-    path("validate-profile-image/", ValidateProfileImageView.as_view(), name="users_alidate_profile_image"),
-    path("profile-image/", ProfileImageCreateView.as_view(), name="users_upload_profile_image"),
+    path("validate-profile-image/", ValidateProfileImageView.as_view(), name="users_validate_profile_image"),
+    path("profile-images/", ProfileImageUploadView.as_view(), name="users_upload_profile_image"),
     # withdrawal
     path(
         "<str:nickname>/validate-withdrawal/",

--- a/src/back-end/web/users/views.py
+++ b/src/back-end/web/users/views.py
@@ -17,7 +17,12 @@ from drf_spectacular.utils import (
 )
 from rest_framework import serializers, status
 from rest_framework.exceptions import ValidationError
-from rest_framework.generics import CreateAPIView, GenericAPIView
+from rest_framework.generics import (
+    CreateAPIView,
+    GenericAPIView,
+    UpdateAPIView,
+    get_object_or_404,
+)
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.validators import UniqueValidator
@@ -28,6 +33,7 @@ from users.serializers import (
     GoogleLoginSerializer,
     NaverLoginSerializer,
     NicknameSerializer,
+    ProfileImageSerializer,
     UserSignUpVerifySerializer,
 )
 
@@ -237,12 +243,24 @@ class ValidateNicknameView(GenericAPIView):
 class ValidateProfileImageView(GenericAPIView):
     """Validation about profile image to use"""
 
+    queryset = User.objects.all()
+    serializer_class = ProfileImageSerializer
 
-@extend_schema(tags=["Priority-1", "User"], operation_id="프로필사진 업로드")
-class ProfileImageCreateView(CreateAPIView):
+
+class ProfileImageUploadView(CreateAPIView, UpdateAPIView):
     """Upload profile image of user"""
 
-    # TODO
+    queryset = User.objects.all()
+    serializer_class = ProfileImageSerializer
+    http_method_names = ["post", "patch"]
+
+    def get_object(self):
+        """Get request user"""
+        # Get login user
+        obj = get_object_or_404(self.get_queryset(), id=self.request.user.id)
+        # May raise a permission denied
+        self.check_object_permissions(self.request, obj)
+        return obj
 
 
 @extend_schema(tags=["Priority-1", "User"], operation_id="회원 탈퇴 가능 여부 확인")

--- a/src/back-end/web/users/views.py
+++ b/src/back-end/web/users/views.py
@@ -13,6 +13,7 @@ from drf_spectacular.utils import (
     OpenApiParameter,
     OpenApiResponse,
     extend_schema,
+    extend_schema_view,
     inline_serializer,
 )
 from rest_framework import serializers, status
@@ -247,6 +248,13 @@ class ValidateProfileImageView(GenericAPIView):
     serializer_class = ProfileImageSerializer
 
 
+@extend_schema_view(
+    operation_id="프로필사진 업로드",
+    post=extend_schema(tags=["Deprecated"], operation_id="프로필사진 업로드", description="Upload in Back-end and set URL"),
+    patch=extend_schema(
+        tags=["Priority-1", "User"], operation_id="프로필사진 URL 변경", description="Set url(uploaded in Front-End)"
+    ),
+)
 class ProfileImageUploadView(CreateAPIView, UpdateAPIView):
     """Upload profile image of user"""
 

--- a/src/back-end/web/users/views.py
+++ b/src/back-end/web/users/views.py
@@ -270,6 +270,13 @@ class ProfileImageUploadView(CreateAPIView, UpdateAPIView):
         self.check_object_permissions(self.request, obj)
         return obj
 
+    def create(self, request, *args, **kwargs):
+        """Upload profile image in BACK-END Server"""
+        # parser_classes = (MultiPartParser, FormParser)
+        # Not implemented yet
+        # Upload image file in S3 from multipart/form-data
+        return super().create(request, args, kwargs)
+
 
 @extend_schema(tags=["Priority-1", "User"], operation_id="회원 탈퇴 가능 여부 확인")
 class ValidateWithdrawalView(GenericAPIView):


### PR DESCRIPTION
# 개요
- 프로필사진 업로드 API 구현

# 세부사항
- 프로필사진 
  - (설계만) POST: multipart/form-data, 프론트에서 이미지 전송, 백엔드에서 이미지 업로드, 이미지 URL 변경
  - (구현) PATCH: application/json, 프론트에서 이미지 업로드 후 URL 전송, 백엔드에서 이미지 URL 변경

# 참고
- 백엔드 S3 이미지 업로드 설정은 전부 되어있어요!
- 다만, 전자는 ImageField, 후자는 URLField로 저장해야 해서 전자(POST) API는 구현 제외했습니다.

# PR
- @KimKimJungyeon 


# Related Issue

- Resolve #112