### PR TITLE
<#161> Response Body snake_case -> camelCase 변환

### DIFF
--- a/src/back-end/web/config/settings/base.py
+++ b/src/back-end/web/config/settings/base.py
@@ -91,9 +91,9 @@ REST_FRAMEWORK = {
         "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer",
     ),
     "DEFAULT_PARSER_CLASSES": (
+        "djangorestframework_camel_case.parser.CamelCaseJSONParser",
         "djangorestframework_camel_case.parser.CamelCaseFormParser",
         "djangorestframework_camel_case.parser.CamelCaseMultiPartParser",
-        "djangorestframework_camel_case.parser.CamelCaseJSONParser",
     ),
     "JSON_UNDERSCOREIZE": {
         "no_underscore_before_number": True,

--- a/src/back-end/web/config/settings/base.py
+++ b/src/back-end/web/config/settings/base.py
@@ -85,6 +85,19 @@ INSTALLED_APPS = [
 ] + CUSTOM_APPS
 
 REST_FRAMEWORK = {
+    # camel case converter
+    "DEFAULT_RENDERER_CLASSES": (
+        "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
+        "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer",
+    ),
+    "DEFAULT_PARSER_CLASSES": (
+        "djangorestframework_camel_case.parser.CamelCaseFormParser",
+        "djangorestframework_camel_case.parser.CamelCaseMultiPartParser",
+        "djangorestframework_camel_case.parser.CamelCaseJSONParser",
+    ),
+    "JSON_UNDERSCOREIZE": {
+        "no_underscore_before_number": True,
+    },
     # API document automation: drf-spectacular
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     # Permit only to authenticated user

--- a/src/back-end/web/requirements.txt
+++ b/src/back-end/web/requirements.txt
@@ -43,6 +43,7 @@ django-guardian==2.4.0
 django-redis==5.2.0
 django-storages==1.12.3
 djangorestframework==3.13.1
+djangorestframework-camel-case==1.3.0
 djangorestframework-simplejwt==5.1.0
 drf-spectacular==0.22.0
 drf-yasg==1.20.0

--- a/src/back-end/web/users/schemas.py
+++ b/src/back-end/web/users/schemas.py
@@ -1,0 +1,30 @@
+"""drf-spectacular api schemas"""
+from drf_spectacular.utils import OpenApiExample
+
+# Return example of Logins(General or Social)
+TOKEN_WITH_USER_LOGIN_SUCCESS_RESPONSE_EXAMPLE = OpenApiExample(
+    response_only=True,
+    name="Success Example",
+    value={
+        "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+        ".eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNjUyMjE3Mjg0LCJpYXQiOjE2NTIyMTAwODQsImp0aSI6IjA0ODY3"
+        "NjA2NTIzMzRmMDhiN2Q3MTc2NjQ0NTg3YjI3IiwidXNlcl9pZCI6Mjl9.CDOzt"
+        "k-o6jvEbfdzAouTAgIypzFgAcm4jbRzzGeDais",
+        "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+        ".eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTY1MjIzMTY4NCwiaW"
+        "F0IjoxNjUyMjEwMDg0LCJqdGkiOiIwNjUxZjdlNGJlMDY0ZjEzYWY5MjU2ZGIyN"
+        "GVlNTVkNiIsInVzZXJfaWQiOjI5fQ.ael6_7GMvE39X6qESW__gikrLrbQAeYTtAllWmN_sYc",
+        "user": {
+            "nickname": "Ongot",
+            "name": "ongot",
+            "email": "ongot@123.com",
+            "cellPhoneNumber": "010-1111-1111",
+            "profileImageUrl": "https://upload.wikimedia.org/wikipedia/"
+            "commons/thumb/a/ab/Swagger-logo.png/150px-Swagger"
+            "-logo.png",
+            "birthday": "1998-01-01",
+            "isActive": True,
+            "isVerified": True,
+        },
+    },
+)

--- a/src/back-end/web/users/views.py
+++ b/src/back-end/web/users/views.py
@@ -24,6 +24,7 @@ from rest_framework.validators import UniqueValidator
 from rest_framework_simplejwt.views import TokenRefreshView
 from users.exceptions import NicknameValidationException
 from users.models import User
+from users.schemas import TOKEN_WITH_USER_LOGIN_SUCCESS_RESPONSE_EXAMPLE
 from users.serializers import (
     GoogleLoginSerializer,
     NaverLoginSerializer,
@@ -53,8 +54,7 @@ from users.serializers import (
     ],
     responses={
         200: OpenApiResponse(
-            description="네이버 로그인 성공",
-            response=JWTSerializer,
+            response=JWTSerializer, description="네이버 로그인 성공", examples=[TOKEN_WITH_USER_LOGIN_SUCCESS_RESPONSE_EXAMPLE]
         )
     },
 )
@@ -73,14 +73,14 @@ class NaverLoginView(SocialLoginView):
     parameters=[
         OpenApiParameter(
             name="set-cookie ",
-            description="ongot-token={{ Access Token }}",
+            description="ongot-token={{Access Token}}; expires=DAY, DD MON 2022 hh:mm:ss GMT; Max-Age=39600;",
             type=str,
             location="cookie",
             response=True,
         ),
         OpenApiParameter(
             name="set-cookie",
-            description="ongot-refresh-token={{ Refresh Token }}",
+            description="ongot-refresh-token={{Refresh Token}}; expires=DAY, DD MON 2022 hh:mm:ss GMT; Max-Age=54000;",
             type=str,
             location="cookie",
             response=True,
@@ -88,8 +88,7 @@ class NaverLoginView(SocialLoginView):
     ],
     responses={
         200: OpenApiResponse(
-            description="구글 로그인 성공",
-            response=JWTSerializer,
+            response=JWTSerializer, description="구글 로그인 성공", examples=[TOKEN_WITH_USER_LOGIN_SUCCESS_RESPONSE_EXAMPLE]
         )
     },
 )
@@ -259,7 +258,15 @@ class UserWithdrawalView(GenericAPIView):
     # TODO
 
 
-@extend_schema(tags=["User"], operation_id="일반 로그인")
+@extend_schema(
+    tags=["User"],
+    operation_id="일반 로그인",
+    responses={
+        200: OpenApiResponse(
+            response=JWTSerializer, description="일반 로그인 성공", examples=[TOKEN_WITH_USER_LOGIN_SUCCESS_RESPONSE_EXAMPLE]
+        )
+    },
+)
 class GeneralLoginView(LoginView):
     """Inherit class of dj_rest_auth LoginView"""
 

--- a/src/back-end/web/users/views.py
+++ b/src/back-end/web/users/views.py
@@ -117,10 +117,10 @@ class GoogleLoginView(SocialLoginView):
                         required=app_settings.USERNAME_REQUIRED,
                         validators=[UniqueValidator(queryset=User.objects.all())],
                     ),
-                    "profile_image_url": serializers.URLField(required=False),
+                    "profileImageUrl": serializers.URLField(required=False),
                     "name": serializers.CharField(),
                     "email": serializers.EmailField(),
-                    "is_verified": serializers.BooleanField(),
+                    "isVerified": serializers.BooleanField(),
                 },
             ),
         )

--- a/src/back-end/web/users/views.py
+++ b/src/back-end/web/users/views.py
@@ -77,6 +77,12 @@ class NaverLoginView(SocialLoginView):
 @extend_schema(
     tags=["Priority-1", "User"],
     operation_id="구글 로그인",
+    request=inline_serializer(
+        name="GoogleOAuth2LoginSerializer",
+        fields={
+            "accessToken": serializers.CharField(),
+        },
+    ),
     parameters=[
         OpenApiParameter(
             name="set-cookie ",
@@ -111,6 +117,18 @@ class GoogleLoginView(SocialLoginView):
 @extend_schema(
     tags=["Priority-1", "User"],
     operation_id="회원 가입",
+    request=inline_serializer(
+        name="SignUpRequestSerializer",
+        fields={
+            "nickname": serializers.CharField(
+                max_length=get_username_max_length(),
+                min_length=app_settings.USERNAME_MIN_LENGTH,
+                required=app_settings.USERNAME_REQUIRED,
+                validators=[UniqueValidator(queryset=User.objects.all())],
+            ),
+            "profileImageUrl": serializers.URLField(required=False),
+        },
+    ),
     responses={
         200: OpenApiResponse(
             description="회원 가입 성공",


### PR DESCRIPTION
# 개요
- application/json response 시 camelCase로 리턴하도록 설정
- 사용자 API 문서 camelCase 반영하도록 일부 수정

# 세부사항
- `djangorestframework-camel-case` 의존성 추가
- case-converter를 적용하여 리턴 필드를 snake_case -> camelCase로 변환
- JSON convention에 적합하게 수정

# 참고
- 이제 (시리얼라이저 변동 없이) api 문서와 리턴 데이터에 camelCase가 기본 적용 되는데요.
- 형식이 복잡해지거나 response에 시리얼라이저를 직접 지정하면 스키마가 잘 안 먹네요!
- 저는 도~~~~저히 적용이 안 되어 example에 지정하는 방식으로 해결했습니다 T-T
- 다르게 해결하셨으면 조언 부탁드리고, 아니라면 제 코드 참고해주세요!

# PR
- @KimKimJungyeon 
