### PR TITLE
<#216> 작품 API - 상세페이지, 홈화면 API 개선

### DIFF
--- a/src/back-end/web/requirements.txt
+++ b/src/back-end/web/requirements.txt
@@ -86,6 +86,7 @@ py==1.11.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21
+pycountry==22.3.5
 Pygments==2.11.2
 PyJWT==2.3.0
 pylint==2.13.5

--- a/src/back-end/web/videos/views/detail_views.py
+++ b/src/back-end/web/videos/views/detail_views.py
@@ -231,7 +231,8 @@ class DetailView(viewsets.ViewSet):
             "poster_url": tv.poster_key,
             "title": tv.title,
             "title_english": tv.title_english,
-            "release_date": tv.release_date,
+            "release_year": str(tv.release_date.year),
+            "release_date": tv.release_date.strftime("%m-%d"),
             "film_rating": tv.film_rating,
             "overview": season_json_ob["overview"],
             "providers": tv_info_response["provider_list"],
@@ -241,9 +242,8 @@ class DetailView(viewsets.ViewSet):
             "total_episodes": tv_json_ob["number_of_episodes"],
             "seasons": season_list,
             "public": {"wish_count": tv.videototalcount.wish_count},
+            "personal": {"wished": None},
         }
-
-        context["personal"] = {"wished": None}
 
         if request.user.is_authenticated:
             context = self.video_personal_count(request.user, tv.id, context)
@@ -350,16 +350,16 @@ class DetailView(viewsets.ViewSet):
             "video_id": movie.id,
             "poster_url": movie.poster_key,
             "title": movie.title,
-            "release_date": movie.release_date,
+            "release_year": str(movie.release_date.year),
+            "release_date": movie.release_date.strftime("%m-%d"),
             "title_english": movie.title_english,
             "overview": overview,
             "providers": movie_info_response["provider_list"],
             "genres": movie_info_response["genre_list"],
             "production_countries": movie_info_response["production_country_list"],
             "public": {"wish_count": movie.videototalcount.wish_count},
+            "personal": {"wished": None},
         }
-
-        context["personal"] = {"wished": None}
 
         if request.user.is_authenticated:
             context = self.video_personal_count(request.user, movie.id, context)

--- a/src/back-end/web/videos/views/detail_views.py
+++ b/src/back-end/web/videos/views/detail_views.py
@@ -18,8 +18,9 @@ from drf_spectacular.utils import (
 from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
+from video_providers.models import VideoProvider
 from videos.exceptions import WrongVideoIDException
-from videos.models import Video
+from videos.models import Genre, ProductionCountry, Video
 from wishes.models import Wish
 
 
@@ -69,17 +70,17 @@ class DetailView(viewsets.ViewSet):
     def get_video_info(self, video_id):
         """Method: get to video info in DB"""
         video_provider = (
-            Video.objects.filter(Q(id=video_id))
+            VideoProvider.objects.filter(Q(video=video_id))
             .values_list(
-                "videoprovider__link",
-                "videoprovider__provider__name",
-                "videoprovider__provider__logo_key",
+                "link",
+                "provider__name",
+                "provider__logo_key",
             )
             .distinct()
         )
 
-        video_genre = Video.objects.filter(Q(id=video_id)).values_list("genre__name")
-        video_production_country = Video.objects.filter(Q(id=video_id)).values_list("productioncountry__name")
+        video_genre = Genre.objects.filter(Q(video=video_id)).values_list("name")
+        video_production_country = ProductionCountry.objects.filter(Q(video=video_id)).values_list("name")
 
         video_info = {
             "video_provider": video_provider,

--- a/src/back-end/web/videos/views/detail_views.py
+++ b/src/back-end/web/videos/views/detail_views.py
@@ -1,8 +1,10 @@
 """APIs of Video application : DetailView"""
 # pylint: disable=R0914
 
+import gettext
 import json
 
+import pycountry
 import requests
 from config.exceptions.result import VideoNotFoundException
 from django.conf import settings
@@ -107,8 +109,11 @@ class DetailView(viewsets.ViewSet):
             genre_list.append(item[0])
 
         production_country_list = []
+        get = gettext.translation("iso3166", pycountry.LOCALES_DIR, languages=["ko"])
+        get.install()
         for item in video_info_list["video_production_country"]:
-            production_country_list.append(item[0])
+            country_name = get.gettext(pycountry.countries.get(alpha_2=item[0]).name)
+            production_country_list.append(country_name)
 
         return {
             "provider_list": provider_list,

--- a/src/back-end/web/videos/views/detail_views.py
+++ b/src/back-end/web/videos/views/detail_views.py
@@ -155,7 +155,8 @@ class DetailView(viewsets.ViewSet):
                             "posterUrl": "https://image.tmdb.org/t/p/w500/ekp9PbSODHiTXXqnHJ4Sq6YHkhq.jpg",
                             "title": "블리치",
                             "titleEnglish": "Bleach",
-                            "releaseDate": "2004-10-05",
+                            "releaseYear": "2004",
+                            "releaseDate": "10-05",
                             "filmRating": None,
                             "overview": "",
                             "providers": [
@@ -166,7 +167,7 @@ class DetailView(viewsets.ViewSet):
                                 }
                             ],
                             "genres": ["Action & Adventure", "애니메이션", "Sci-Fi & Fantasy"],
-                            "productionCountries": ["JP"],
+                            "productionCountries": ["일본"],
                             "totalSeasons": 1,
                             "totalEpisodes": 366,
                             "seasons": [{"number": 0, "name": "스페셜"}, {"number": 1, "name": "시즌 1"}],
@@ -274,13 +275,14 @@ class DetailView(viewsets.ViewSet):
                             "videoId": 8,
                             "posterUrl": "https://image.tmdb.org/t/p/w500/zDNAeWU0PxKolEX1D8Vn1qWhGjH.jpg",
                             "title": "인터스텔라",
-                            "releaseDate": "2014-11-05",
+                            "releaseYear": "2014",
+                            "releaseDate": "11-05",
                             "titleEnglish": "Interstellar",
                             "overview": (
-                                "세계 각국의 정부와 경제가 완전히 붕괴된 미래가 다가온다. 지난 20세기에 범한 잘못이"
-                                "전 세계적인 식량 부족을 불러왔고, NASA도 해체되었다. 나사 소속 우주비행사였던 쿠퍼는 지구에 몰아친 식량난으로 옥수수나 키우며 살고 있다."
-                                "거센 황사가 몰아친 어느 날 알 수 없는 힘에 이끌려 딸과 함께 도착한 곳은 인류가 이주할 행성을 찾는 나사의 비밀본부."
-                                "이 때 시공간에 불가사의한 틈이 열리고, 이 곳을 탐험해 인류를 구해야 하는 임무를 위해 쿠퍼는 만류하는 딸을 뒤로한 채 우주선에 탑승하는데..."
+                                "세계 각국의 정부와 경제가 완전히 붕괴된 미래가 다가온다. 지난 20세기에 범한 잘못이 전 세계적인 식량 부족을 불러왔고, NASA도 해체되었다."
+                                " 나사 소속 우주비행사였던 쿠퍼는 지구에 몰아친 식량난으로 옥수수나 키우며 살고 있다. 거센 황사가 몰아친 어느 날 알 수 없는 힘에 이끌려 딸과 "
+                                "함께 도착한 곳은 인류가 이주할 행성을 찾는 나사의 비밀본부. 이 때 시공간에 불가사의한 틈이 열리고, 이 곳을 탐험해 인류를 구해야 하는 임무를"
+                                " 위해 쿠퍼는 만류하는 딸을 뒤로한 채 우주선에 탑승하는데..."
                             ),
                             "providers": [
                                 {
@@ -300,8 +302,8 @@ class DetailView(viewsets.ViewSet):
                                 },
                             ],
                             "genres": ["모험", "드라마", "SF"],
-                            "productionCountries": ["GB", "US"],
-                            "public": {"wishCount": 153},
+                            "productionCountries": ["영국", "미국"],
+                            "public": {"wishCount": 0},
                             "personal": {"wished": False},
                         },
                     )

--- a/src/back-end/web/videos/views/home_views.py
+++ b/src/back-end/web/videos/views/home_views.py
@@ -156,7 +156,7 @@ class HomeView(viewsets.ViewSet):
             _p = providers.split(",")
             _filter &= Q(videoprovider__provider__name__in=_p)
 
-        if genres:
+        if (genres is not None) & (genres != "all"):
             _genres = genres.split(",")
             _filter &= Q(genre__name__in=_genres)
 

--- a/src/back-end/web/videos/views/home_views.py
+++ b/src/back-end/web/videos/views/home_views.py
@@ -119,8 +119,8 @@ class HomeView(viewsets.ViewSet):
 
     sort_dict = {
         "random": "id",
-        "new": "videoprovider__offer_date",
-        "release": "release_date",
+        "new": "-videoprovider__offer_date",
+        "release": "-release_date",
     }
     """
     + Sort:


### PR DESCRIPTION

# 개요
- 작품 1순위 API인 상세페이지, 홈화면 API 관련 개선

# 세부사항
- 장르 필터링시 all 처리 가능하게 수정
- 상세 페이지에서 release_year, release_date로 분리 (연, 월-일 형식)
- 상세 페이지 국가정보 한국어로 출력 되도록 수정
- 작품 상세 페이지 처리 할 때 교수님 피드백 받아서 Video에서 쿼리호출 하는 형식이 아닌 각자 table에서 쿼리 호출하는 식으로 변경

# 참고
- 리뷰 한번 해주신 다음에 정보 확인할 수 있게 아성이 태그해주세요!
- postman은 미처리 상태, 스웨거엔 example 처리 O , postman은 내일 일괄 처리 하겠습니다.

# PR
- @dadahee 


# Related Issue

- Resolve #216