### PR TITLE
<#221> link-milestone 액션 주석처리

### DIFF
--- a/.github/workflows/pr-support.yml
+++ b/.github/workflows/pr-support.yml
@@ -17,12 +17,12 @@ jobs:
         position: 'bottom'
         resolve: true
         link-style: "body"
-  link-milestone:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: andrefcdias/add-to-milestone@v1.2.2
-      name: Link current milestone to pull request
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        milestone: "~ *"
-        use-expression: true
+#  link-milestone:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: andrefcdias/add-to-milestone@v1.2.2
+#      name: Link current milestone to pull request
+#      with:
+#        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+#        milestone: "~ *"
+#        use-expression: true


### PR DESCRIPTION
# 개요
- 불필요한 Github Action 비활성화

# 세부사항
- 속 썩이는 job 주석처리
- pr-supporter 내 link-milestone 기능 비활성화

# 참고
- 아래와 같은 동작 시 status fail 오류가 발생
- 사유
  - 마일스톤 만료 시 마일스톤 못 찾는 에러
  - 마일스톤 연결 후 등록 시 마일스톤 연결 불가 에러

# PR
- @a-sung, @yesslee, @KimKimJungyeon

# Related Issue

- Resolve #221