### PR TITLE
<#227> 작품 API 홈화면 장르 필터링 404 에러 해결 

### DIFF
--- a/src/back-end/web/videos/views/home_views.py
+++ b/src/back-end/web/videos/views/home_views.py
@@ -132,7 +132,7 @@ class HomeView(viewsets.ViewSet):
     filter_default = {
         "providers": None,
         "categories": None,
-        "genres": None,
+        "genres": "",
         "release_date_min": "1800",
         "release_date_max": "2022",
         "production_country": "",
@@ -156,7 +156,7 @@ class HomeView(viewsets.ViewSet):
             _p = providers.split(",")
             _filter &= Q(videoprovider__provider__name__in=_p)
 
-        if (genres is not None) & (genres != "all"):
+        if genres not in ("all", ""):
             _genres = genres.split(",")
             _filter &= Q(genre__name__in=_genres)
 
@@ -197,7 +197,7 @@ class HomeView(viewsets.ViewSet):
         filter_list = {
             "providers": self.request.query_params.get("providers", None),
             "categories": self.request.query_params.get("category", None),
-            "genres": self.request.query_params.get("genres", None),
+            "genres": self.request.query_params.get("genres", ""),
             "release_date_min": self.request.query_params.get("releaseDateMin", "1800"),
             "release_date_max": self.request.query_params.get("releaseDateMax", "2022"),
             "production_country": self.request.query_params.get("productionCountry", ""),


### PR DESCRIPTION
# 개요
- 작품 API 홈화면 장르 필터링시 404 에러 뜨던 문제 해결

# 세부사항
- 빈칸, all일시 장르 필터링 거치지 않고 통과하게 설정
- 효율을 위해서 기존에 None으로 설정했던 default 값 빈칸으로 변경

# 참고
- 확인해주시고 나서 프론트 태그 부탁드려요

# PR
- @dadahee 


# Related Issue

- Resolve #227