### PR TITLE
<#239> 마이페이지 조회 - 찜한 작품 정렬 개선

### DIFF
--- a/src/back-end/web/data.json
+++ b/src/back-end/web/data.json
@@ -17024,5 +17024,86 @@
     },
     "model": "applies.memberapply",
     "pk": 1
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:26:33",
+      "user": 1,
+      "video": 15
+    },
+    "model": "wishes.wish",
+    "pk": 1
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:26:37",
+      "user": 1,
+      "video": 5
+    },
+    "model": "wishes.wish",
+    "pk": 2
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:26:41",
+      "user": 1,
+      "video": 109
+    },
+    "model": "wishes.wish",
+    "pk": 3
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:26:45",
+      "user": 1,
+      "video": 88
+    },
+    "model": "wishes.wish",
+    "pk": 4
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:26:50",
+      "user": 1,
+      "video": 75
+    },
+    "model": "wishes.wish",
+    "pk": 5
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:26:55",
+      "user": 1,
+      "video": 176
+    },
+    "model": "wishes.wish",
+    "pk": 6
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:27:00",
+      "user": 1,
+      "video": 23
+    },
+    "model": "wishes.wish",
+    "pk": 7
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:28:42",
+      "user": 1,
+      "video": 78
+    },
+    "model": "wishes.wish",
+    "pk": 8
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:29:15",
+      "user": 1,
+      "video": 127
+    },
+    "model": "wishes.wish",
+    "pk": 9
   }
 ]

--- a/src/back-end/web/data.json
+++ b/src/back-end/web/data.json
@@ -17105,5 +17105,68 @@
     },
     "model": "wishes.wish",
     "pk": 9
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:31:08",
+      "user": 2,
+      "video": 7
+    },
+    "model": "wishes.wish",
+    "pk": 11
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:48:33",
+      "user": 2,
+      "video": 14
+    },
+    "model": "wishes.wish",
+    "pk": 12
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:48:38",
+      "user": 2,
+      "video": 17
+    },
+    "model": "wishes.wish",
+    "pk": 13
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:48:42",
+      "user": 2,
+      "video": 187
+    },
+    "model": "wishes.wish",
+    "pk": 14
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:49:06",
+      "user": 2,
+      "video": 144
+    },
+    "model": "wishes.wish",
+    "pk": 15
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:50:00",
+      "user": 2,
+      "video": 10
+    },
+    "model": "wishes.wish",
+    "pk": 16
+  },
+  {
+    "fields": {
+      "date_time": "2022-05-23T02:50:09",
+      "user": 2,
+      "video": 12
+    },
+    "model": "wishes.wish",
+    "pk": 17
   }
 ]

--- a/src/back-end/web/mypages/serializers.py
+++ b/src/back-end/web/mypages/serializers.py
@@ -9,6 +9,7 @@ from users.models import User
 from users.serializers import UserSerializer
 from videos.models import Video
 from videos.serializers import VideoHistorySerializer
+from wishes.serializers import WishListSerializer
 
 
 class MyPageSerializer(serializers.Serializer):
@@ -118,11 +119,11 @@ class VideoTotalHistorySerializer(serializers.Serializer):
     wishes = serializers.SerializerMethodField(read_only=True)
     stars = serializers.SerializerMethodField(read_only=True)
 
-    def get_paginated_videos(self, queryset):
+    def get_paginated_videos(self, queryset, serializer=VideoHistorySerializer):
         """Get paginated video histories"""
         paginator = VideoHistoryPagination()
         _page = paginator.paginate_queryset(queryset, self.context.get("request"))
-        return paginator.get_paginated_result(VideoHistorySerializer(_page, many=True).data)
+        return paginator.get_paginated_result(serializer(_page, many=True).data)
 
     def get_recent_views(self, user):
         """Get user's recent view histories"""
@@ -136,8 +137,8 @@ class VideoTotalHistorySerializer(serializers.Serializer):
 
     def get_wishes(self, user):
         """Get user's wish histories"""
-        _queryset = Video.objects.prefetch_related("wish_set__user").filter(wish__user=user).all()
-        return self.get_paginated_videos(_queryset)
+        _wishes = user.wish_set.order_by("-date_time").all()
+        return self.get_paginated_videos(_wishes, WishListSerializer)
 
     def get_stars(self, user):
         """Get user's star histories"""

--- a/src/back-end/web/mypages/views.py
+++ b/src/back-end/web/mypages/views.py
@@ -39,6 +39,8 @@ class MyPageDetailView(APIView):
         "memberapply_set",
         "leaderapply_set__provider",
         "memberapply_set__provider",
+        "wish_set",
+        "wish_set__video",
     )
     serializer_class = MyPageSerializer
 


### PR DESCRIPTION
# 개요
- 마이페이지 조회 API
  - 찜한 작품 목록 정렬 개선

# 세부사항
- 시리얼라이저 변경

# 참고
- 마이페이지 조회 시 찜 목록(default)
  - 마이페이지 전용 작품 목록 시리얼라이저 -> 찜 목록 조회 시리얼라이저로 교체
  - 다른 유형의 작품 기록과 스키마 일부 상이: 작품 기준 -> 찜 기준으로 응답하므로)
  - -> 추후(?) 조회 / 관람체크 등 구현 시 개별 시리얼라이저 필요!
- 개선 후 결과
  - 생성/삭제: 이상무!
    - ![image](https://user-images.githubusercontent.com/39542793/169708262-8cb61d54-c3f8-4e0d-8080-5a3118efe307.png)
  - 조회 결과 비교: #239 코멘트
- 샘플데이터 추가

# PR
- @KimKimJungyeon, @a-sung 


# Related Issue

- Resolve #239