### PR TITLE
<#245> 작품 상세페이지 API 유사작품 리스트 추가

### DIFF
--- a/src/back-end/web/videos/views/detail_views.py
+++ b/src/back-end/web/videos/views/detail_views.py
@@ -73,7 +73,7 @@ class DetailView(viewsets.ViewSet):
             poster_path = similar_json["results"][count]["poster_path"]
             if poster_path:
                 similar_video = {
-                    "poster": f"https://image.tmdb.org/t/p/w500{poster_path}",
+                    "poster_url": f"https://image.tmdb.org/t/p/w500{poster_path}",
                     "title": similar_json["results"][count][naming],
                 }
                 similar_list.append(similar_video)
@@ -195,27 +195,27 @@ class DetailView(viewsets.ViewSet):
                             "personal": {"wished": None},
                             "similar": [
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/fbdM3vtY29PkipKrBb6NuTw7VDt.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/fbdM3vtY29PkipKrBb6NuTw7VDt.jpg",
                                     "title": "교향시편 유레카 세븐",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/k3NQ7gVfnNPWbdCgg0x0Tv8CNNN.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/k3NQ7gVfnNPWbdCgg0x0Tv8CNNN.jpg",
                                     "title": "신세기 에반게리온",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/pOjDuclpsWGV13Nj7XtZukuZj6f.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/pOjDuclpsWGV13Nj7XtZukuZj6f.jpg",
                                     "title": "소녀혁명 우테나",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/9A7q9QjLoTfYLn7zejj7uRYA3IZ.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/9A7q9QjLoTfYLn7zejj7uRYA3IZ.jpg",
                                     "title": "오란고교 사교클럽",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/5dfhAeijI1p5FeY3oOFEGwbuqiZ.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/5dfhAeijI1p5FeY3oOFEGwbuqiZ.jpg",
                                     "title": "사무라이 참프루",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/ej3tcxv2YYVWy6WoOeWZTcrkiI8.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/ej3tcxv2YYVWy6WoOeWZTcrkiI8.jpg",
                                     "title": "시리얼 익스페러먼츠 레인",
                                 },
                             ],
@@ -302,7 +302,7 @@ class DetailView(viewsets.ViewSet):
             "seasons": season_list,
             "public": {"wish_count": tv.videototalcount.wish_count},
             "personal": {"wished": None},
-            "similar": similar_list,
+            "similars": similar_list,
         }
 
         if request.user.is_authenticated:
@@ -349,27 +349,27 @@ class DetailView(viewsets.ViewSet):
                             "personal": {"wished": False},
                             "similar": [
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/cuFPxoFopAjFUz4oIMUzpzeTA8I.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/cuFPxoFopAjFUz4oIMUzpzeTA8I.jpg",
                                     "title": "9 불리츠",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/AmUGn1rJ9XDDP6DYn9OA2uV8MIg.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/AmUGn1rJ9XDDP6DYn9OA2uV8MIg.jpg",
                                     "title": "상티넬",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/2suj5y3WMaSC7zg4L9kMnsRiomy.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/2suj5y3WMaSC7zg4L9kMnsRiomy.jpg",
                                     "title": "G-Zombie",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/x3NZwlJef6xvejLu49Z5l7tFVe7.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/x3NZwlJef6xvejLu49Z5l7tFVe7.jpg",
                                     "title": "Z",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/iPTZGFmPs7HsXHYxiuxGolihjOH.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/iPTZGFmPs7HsXHYxiuxGolihjOH.jpg",
                                     "title": "아미 오브 더 데드: 도둑들",
                                 },
                                 {
-                                    "poster": "https://image.tmdb.org/t/p/w500/vQrResA1HSUuLQIf2EBtB7U5lGJ.jpg",
+                                    "poster_url": "https://image.tmdb.org/t/p/w500/vQrResA1HSUuLQIf2EBtB7U5lGJ.jpg",
                                     "title": "코다",
                                 },
                             ],
@@ -440,7 +440,7 @@ class DetailView(viewsets.ViewSet):
             "production_countries": movie_info_response["production_country_list"],
             "public": {"wish_count": movie.videototalcount.wish_count},
             "personal": {"wished": None},
-            "similar": similar_list,
+            "similars": similar_list,
         }
 
         if request.user.is_authenticated:

--- a/src/back-end/web/videos/views/detail_views.py
+++ b/src/back-end/web/videos/views/detail_views.py
@@ -69,7 +69,7 @@ class DetailView(viewsets.ViewSet):
         similar_list = []
         naming = self.category_title_naming[category_type]
         count = 0
-        while len(similar_list) < 6:
+        while len(similar_list) < 6 or similar_json["total_results"] == count:
             poster_path = similar_json["results"][count]["poster_path"]
             if poster_path:
                 similar_video = {
@@ -182,7 +182,7 @@ class DetailView(viewsets.ViewSet):
                             "providers": [
                                 {
                                     "name": "WV",
-                                    "logoUrl": "https://image.tmdb.org/t/p/original/cNi4Nv5EPsnvf5WmgwhfWDsdMUd.jpg",
+                                    "logoUrl": "https://image.tmdb.org/t/p/original/8N0DNa4BO3lH24KWv1EjJh4TxoD.jpg",
                                     "link": "https://www.wavve.com/",
                                 }
                             ],
@@ -193,6 +193,32 @@ class DetailView(viewsets.ViewSet):
                             "seasons": [{"number": 0, "name": "스페셜"}, {"number": 1, "name": "시즌 1"}],
                             "public": {"wishCount": 0},
                             "personal": {"wished": None},
+                            "similar": [
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/fbdM3vtY29PkipKrBb6NuTw7VDt.jpg",
+                                    "title": "교향시편 유레카 세븐",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/k3NQ7gVfnNPWbdCgg0x0Tv8CNNN.jpg",
+                                    "title": "신세기 에반게리온",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/pOjDuclpsWGV13Nj7XtZukuZj6f.jpg",
+                                    "title": "소녀혁명 우테나",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/9A7q9QjLoTfYLn7zejj7uRYA3IZ.jpg",
+                                    "title": "오란고교 사교클럽",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/5dfhAeijI1p5FeY3oOFEGwbuqiZ.jpg",
+                                    "title": "사무라이 참프루",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/ej3tcxv2YYVWy6WoOeWZTcrkiI8.jpg",
+                                    "title": "시리얼 익스페러먼츠 레인",
+                                },
+                            ],
                         },
                     )
                 ],
@@ -300,39 +326,53 @@ class DetailView(viewsets.ViewSet):
                         response_only=True,
                         name="Success Example",
                         value={
-                            "videoId": 8,
-                            "posterUrl": "https://image.tmdb.org/t/p/w500/zDNAeWU0PxKolEX1D8Vn1qWhGjH.jpg",
-                            "title": "인터스텔라",
-                            "releaseYear": "2014",
-                            "releaseDate": "11-05",
-                            "titleEnglish": "Interstellar",
+                            "videoId": 3,
+                            "posterUrl": "https://image.tmdb.org/t/p/w500/dBz61uAt6xjJt4yqhiZXQt0a1bB.jpg",
+                            "title": "킹덤: 아신전",
+                            "releaseYear": "2021",
+                            "releaseDate": "07-23",
+                            "titleEnglish": "Kingdom: Ashin of the North",
                             "overview": (
-                                "세계 각국의 정부와 경제가 완전히 붕괴된 미래가 다가온다. 지난 20세기에 범한 잘못이 전 세계적인 식량 부족을 불러왔고, NASA도 해체되었다."
-                                " 나사 소속 우주비행사였던 쿠퍼는 지구에 몰아친 식량난으로 옥수수나 키우며 살고 있다. 거센 황사가 몰아친 어느 날 알 수 없는 힘에 이끌려 딸과 "
-                                "함께 도착한 곳은 인류가 이주할 행성을 찾는 나사의 비밀본부. 이 때 시공간에 불가사의한 틈이 열리고, 이 곳을 탐험해 인류를 구해야 하는 임무를"
-                                " 위해 쿠퍼는 만류하는 딸을 뒤로한 채 우주선에 탑승하는데..."
+                                "비극과 배신이 삶을 덮친다. 기이하고 불길한 뭔가를 발견한다. 한순간에 가족과 동족을 잃은 여인."
+                                " 오직 복수를 꿈꾸며 살아온 그녀가 짙은 어둠을 마주한다."
                             ),
                             "providers": [
                                 {
                                     "name": "NF",
                                     "logoUrl": "https://image.tmdb.org/t/p/original/9A1JSVmSxsyaBK4SUFsYVqbAYfW.jpg",
                                     "link": "https://www.netflix.com/kr/",
-                                },
-                                {
-                                    "name": "WV",
-                                    "logoUrl": "https://image.tmdb.org/t/p/original/cNi4Nv5EPsnvf5WmgwhfWDsdMUd.jpg",
-                                    "link": "https://www.wavve.com/",
-                                },
-                                {
-                                    "name": "WC",
-                                    "logoUrl": "https://image.tmdb.org/t/p/original/dgPueyEdOwpQ10fjuhL2WYFQwQs.jpg",
-                                    "link": "https://watcha.com/",
-                                },
+                                }
                             ],
-                            "genres": ["모험", "드라마", "SF"],
-                            "productionCountries": ["영국", "미국"],
+                            "genres": ["드라마", "판타지", "스릴러"],
+                            "productionCountries": ["대한민국"],
                             "public": {"wishCount": 0},
                             "personal": {"wished": False},
+                            "similar": [
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/cuFPxoFopAjFUz4oIMUzpzeTA8I.jpg",
+                                    "title": "9 불리츠",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/AmUGn1rJ9XDDP6DYn9OA2uV8MIg.jpg",
+                                    "title": "상티넬",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/2suj5y3WMaSC7zg4L9kMnsRiomy.jpg",
+                                    "title": "G-Zombie",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/x3NZwlJef6xvejLu49Z5l7tFVe7.jpg",
+                                    "title": "Z",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/iPTZGFmPs7HsXHYxiuxGolihjOH.jpg",
+                                    "title": "아미 오브 더 데드: 도둑들",
+                                },
+                                {
+                                    "poster": "https://image.tmdb.org/t/p/w500/vQrResA1HSUuLQIf2EBtB7U5lGJ.jpg",
+                                    "title": "코다",
+                                },
+                            ],
                         },
                     )
                 ],

--- a/src/back-end/web/videos/views/detail_views.py
+++ b/src/back-end/web/videos/views/detail_views.py
@@ -195,27 +195,27 @@ class DetailView(viewsets.ViewSet):
                             "personal": {"wished": None},
                             "similar": [
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/fbdM3vtY29PkipKrBb6NuTw7VDt.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/fbdM3vtY29PkipKrBb6NuTw7VDt.jpg",
                                     "title": "교향시편 유레카 세븐",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/k3NQ7gVfnNPWbdCgg0x0Tv8CNNN.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/k3NQ7gVfnNPWbdCgg0x0Tv8CNNN.jpg",
                                     "title": "신세기 에반게리온",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/pOjDuclpsWGV13Nj7XtZukuZj6f.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/pOjDuclpsWGV13Nj7XtZukuZj6f.jpg",
                                     "title": "소녀혁명 우테나",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/9A7q9QjLoTfYLn7zejj7uRYA3IZ.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/9A7q9QjLoTfYLn7zejj7uRYA3IZ.jpg",
                                     "title": "오란고교 사교클럽",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/5dfhAeijI1p5FeY3oOFEGwbuqiZ.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/5dfhAeijI1p5FeY3oOFEGwbuqiZ.jpg",
                                     "title": "사무라이 참프루",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/ej3tcxv2YYVWy6WoOeWZTcrkiI8.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/ej3tcxv2YYVWy6WoOeWZTcrkiI8.jpg",
                                     "title": "시리얼 익스페러먼츠 레인",
                                 },
                             ],
@@ -349,27 +349,27 @@ class DetailView(viewsets.ViewSet):
                             "personal": {"wished": False},
                             "similar": [
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/cuFPxoFopAjFUz4oIMUzpzeTA8I.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/cuFPxoFopAjFUz4oIMUzpzeTA8I.jpg",
                                     "title": "9 불리츠",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/AmUGn1rJ9XDDP6DYn9OA2uV8MIg.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/AmUGn1rJ9XDDP6DYn9OA2uV8MIg.jpg",
                                     "title": "상티넬",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/2suj5y3WMaSC7zg4L9kMnsRiomy.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/2suj5y3WMaSC7zg4L9kMnsRiomy.jpg",
                                     "title": "G-Zombie",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/x3NZwlJef6xvejLu49Z5l7tFVe7.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/x3NZwlJef6xvejLu49Z5l7tFVe7.jpg",
                                     "title": "Z",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/iPTZGFmPs7HsXHYxiuxGolihjOH.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/iPTZGFmPs7HsXHYxiuxGolihjOH.jpg",
                                     "title": "아미 오브 더 데드: 도둑들",
                                 },
                                 {
-                                    "poster_url": "https://image.tmdb.org/t/p/w500/vQrResA1HSUuLQIf2EBtB7U5lGJ.jpg",
+                                    "posterUrl": "https://image.tmdb.org/t/p/w500/vQrResA1HSUuLQIf2EBtB7U5lGJ.jpg",
                                     "title": "코다",
                                 },
                             ],


### PR DESCRIPTION

# 개요
- 작품 상세 페이지 API에서 유사 작품 리스트가 추가되도록 구현

# 세부사항
- 최대 6개 리스트로, API 호출로 나온 작품 갯수가 그것보다 적을 시엔 최대한 많이 가져올 수 있게 로직 작성
- 일단 화면이 풍족하게 보이는 게 목적이라 따로 포스터 이미지가 없다 이러면 받아오지 않게 함

# 참고
- postman 수정 예정
- 스웨거는 example 수정 완료함

# PR
- @dadahee 


# Related Issue

- Resolve #245