### PR TITLE
<#244> 작품 API - 작품 홈 화면 API 정렬 조건 개선

### DIFF
--- a/src/back-end/web/videos/views/home_views.py
+++ b/src/back-end/web/videos/views/home_views.py
@@ -52,7 +52,9 @@ class VideoListPagination(LimitOffsetPagination):
         OpenApiParameter(
             name="productionCountry", description="condtion of filtering video production country : KR, OTHER", type=str
         ),
-        OpenApiParameter(name="sort", description="video sort condition : random, new, release", type=str),
+        OpenApiParameter(
+            name="sort", description="video sort condition : default, random, new, release, order", type=str
+        ),
         OpenApiParameter(name="limit", description="number of Videos to display", type=int),
         OpenApiParameter(name="offset", description="number of Videos list Start point", type=int),
     ],
@@ -118,9 +120,11 @@ class HomeView(viewsets.ViewSet):
     permission_classes = (permissions.AllowAny,)
 
     sort_dict = {
-        "random": "id",
+        "default": "id",
+        "random": "?",
         "new": "-videoprovider__offer_date",
         "release": "-release_date",
+        "order": "title",
     }
     """
     + Sort:
@@ -220,7 +224,7 @@ class HomeView(viewsets.ViewSet):
         Sort : sort videos ramndom, new, release
         """
 
-        sort = self.request.query_params.get("sort", default="random")
+        sort = self.request.query_params.get("sort", default="default")
         try:
             queryset = queryset.order_by(self.sort_dict[sort], "id")
         except KeyError as e:

--- a/src/back-end/web/videos/views/home_views.py
+++ b/src/back-end/web/videos/views/home_views.py
@@ -222,8 +222,7 @@ class HomeView(viewsets.ViewSet):
 
         sort = self.request.query_params.get("sort", default="random")
         try:
-            if sort:
-                queryset = queryset.order_by(self.sort_dict[sort], "id")
+            queryset = queryset.order_by(self.sort_dict[sort], "id")
         except KeyError as e:
             raise BadFormatException() from e
 

--- a/src/back-end/web/videos/views/home_views.py
+++ b/src/back-end/web/videos/views/home_views.py
@@ -223,7 +223,7 @@ class HomeView(viewsets.ViewSet):
         sort = self.request.query_params.get("sort", default="random")
         try:
             if sort:
-                queryset = queryset.order_by(self.sort_dict[sort])
+                queryset = queryset.order_by(self.sort_dict[sort], "id")
         except KeyError as e:
             raise BadFormatException() from e
 


### PR DESCRIPTION

# 개요
- 홈 화면 API의 정렬 조건을 개선, 추가한다.

# 세부사항
- 정렬 조건 개선
  -  조건이 동일 할 시에 작품 id 우선으로 정렬되게 개선
  - random 조건 시 작품 id 순이 아닌 랜덤하게 작품 정렬이 계속 바뀔수 있게 변경
- 정렬 조건 추가 = 가나다 순 (order), 작품 id순(default)
  - sort 입력 x 시 작품 id순, 공백 입력시 작품 id 순으로 출력됨.

# 참고
- postman 수정 예정

# PR
- @dadahee 


# Related Issue

- Resolve #244