### PR TITLE
<#265> 작품 api - API 정렬 조건 문제 해결

### DIFF
--- a/src/back-end/web/videos/urls.py
+++ b/src/back-end/web/videos/urls.py
@@ -5,7 +5,7 @@ from videos.views.home_views import HomeView
 from wishes.views import WishCreateAndDestroyView
 
 urlpatterns = [
-    path("", HomeView.as_view({"get": "list"}), name="home_video_list"),
+    path("", (HomeView.as_view({"get": "list"})), name="home_video_list"),
     path("tv/<int:video_id>/", tv_season_redirect_view, name="redirect_tv_detail"),
     path("tv/<int:video_id>/seasons/<int:season_num>/", DetailView.as_view({"get": "tv_details"}), name="tv_details"),
     path("movie/<int:video_id>/", DetailView.as_view({"get": "movie_details"}), name="movie_detail"),

--- a/src/back-end/web/videos/views/home_views.py
+++ b/src/back-end/web/videos/views/home_views.py
@@ -1,6 +1,8 @@
 """APIs of Video application : HomeView"""
 # pylint: disable=R0914
 
+from random import shuffle
+
 from config.exceptions.input import BadFormatException
 from config.exceptions.result import ResultNotFoundException
 from django.db.models import Q
@@ -121,7 +123,6 @@ class HomeView(viewsets.ViewSet):
 
     sort_dict = {
         "default": "id",
-        "random": "?",
         "new": "-videoprovider__offer_date",
         "release": "-release_date",
         "order": "title",
@@ -225,8 +226,13 @@ class HomeView(viewsets.ViewSet):
         """
 
         sort = self.request.query_params.get("sort", default="default")
+
         try:
-            queryset = queryset.order_by(self.sort_dict[sort], "id")
+            if sort != "random":
+                queryset = queryset.order_by(self.sort_dict[sort], "id").distinct()
+            else:
+                queryset = list(queryset)
+                shuffle(queryset)
         except KeyError as e:
             raise BadFormatException() from e
 

--- a/src/back-end/web/videos/views/home_views.py
+++ b/src/back-end/web/videos/views/home_views.py
@@ -1,7 +1,6 @@
 """APIs of Video application : HomeView"""
 # pylint: disable=R0914
 
-from random import shuffle
 
 from config.exceptions.input import BadFormatException
 from config.exceptions.result import ResultNotFoundException
@@ -54,9 +53,7 @@ class VideoListPagination(LimitOffsetPagination):
         OpenApiParameter(
             name="productionCountry", description="condtion of filtering video production country : KR, OTHER", type=str
         ),
-        OpenApiParameter(
-            name="sort", description="video sort condition : default, random, new, release, order", type=str
-        ),
+        OpenApiParameter(name="sort", description="video sort condition : random, new, release, order", type=str),
         OpenApiParameter(name="limit", description="number of Videos to display", type=int),
         OpenApiParameter(name="offset", description="number of Videos list Start point", type=int),
     ],
@@ -122,7 +119,7 @@ class HomeView(viewsets.ViewSet):
     permission_classes = (permissions.AllowAny,)
 
     sort_dict = {
-        "default": "id",
+        "random": "id",
         "new": "-videoprovider__offer_date",
         "release": "-release_date",
         "order": "title",
@@ -225,14 +222,11 @@ class HomeView(viewsets.ViewSet):
         Sort : sort videos ramndom, new, release
         """
 
-        sort = self.request.query_params.get("sort", default="default")
+        sort = self.request.query_params.get("sort", default="random")
 
         try:
-            if sort != "random":
-                queryset = queryset.order_by(self.sort_dict[sort], "id").distinct()
-            else:
-                queryset = list(queryset)
-                shuffle(queryset)
+            if sort:
+                queryset = queryset.order_by(self.sort_dict[sort], "id")
         except KeyError as e:
             raise BadFormatException() from e
 


### PR DESCRIPTION

# 개요
- 홈화면 API 에서 random 정렬시 생기던 문제 해결 

# 세부사항
- default 정렬 조건 삭제 -> random으로 변경.
- random은 id 기준으로 정렬되도록 설정

# 참고
- 제대로 random 구현은 추후 cache사용으로 구현 예정.

# PR
- @dadahee 


# Related Issue

- Resolve #265