### PR TITLE
<#273> 왓챠 로고 데이터 수정 및 크롤러 DB구조에 맞게 수정

### DIFF
--- a/src/back-end/crawler/saving_DB.py
+++ b/src/back-end/crawler/saving_DB.py
@@ -97,25 +97,8 @@ def save_provider_data(video_provider_data):
             cursor.execute(sql_provider)
             provider_id = cursor.fetchall()[0][0]
 
-            """provider base save"""
-            sql = "INSERT INTO video_providers (video_id, offer_type,link,offer_date,deadline) VALUES (%s,%s,%s,%s,%s)"
-            values = (video_id, obj["offer_type"], obj["link"], item["crawling_time"], None)
-            cursor.execute(sql, values)
-            conn.commit()
-
-            """provider - video providers M:N relationship connect"""
-            if obj["offer_type"] == None:
-                sql = "SELECT id FROM video_providers WHERE video_id = %s AND offer_type IS NULL AND link= %s"
-                values = (video_id, obj["link"])
-            else:
-                sql = "SELECT id FROM video_providers WHERE video_id = %s AND offer_type =%s AND link= %s"
-                values = (video_id, obj["offer_type"], obj["link"])
-
-            cursor.execute(sql, values)
-
-            video_provider_id = cursor.fetchall()[0][0]
-            sql = "INSERT INTO video_providers_provider (videoprovider_id, provider_id) VALUES (%s,%s)"
-            values = (video_provider_id, provider_id)
+            sql = "INSERT INTO video_providers (video_id, provider_id, offer_type,link,offer_date,deadline) VALUES (%s,%s,%s,%s,%s,%s)"
+            values = (video_id, provider_id, obj["offer_type"], obj["link"], item["crawling_time"], None)
             cursor.execute(sql, values)
             conn.commit()
 

--- a/src/back-end/crawler/setting_provider.py
+++ b/src/back-end/crawler/setting_provider.py
@@ -23,13 +23,14 @@ conn = MySQLdb.connect(
 )
 cursor = conn.cursor()
 
-watch_providers = {"8": "NF", "337": "WV", "356": "WC", "97": "DP", "119": "AP"}
+watch_providers = {"8": "NF", "337": "WV", "356": "WC", "97": "DP", "119": "AP", "0": "LF"}
 logo_key = {
     "8": "https://image.tmdb.org/t/p/original/9A1JSVmSxsyaBK4SUFsYVqbAYfW.jpg",
     "337": "https://image.tmdb.org/t/p/original/8N0DNa4BO3lH24KWv1EjJh4TxoD.jpg",
-    "356": "https://image.tmdb.org/t/p/original/cNi4Nv5EPsnvf5WmgwhfWDsdMUd.jpg",
+    "356": "https://oopy.lazyrockets.com/api/rest/cdn/image/99453fde-4624-457f-8471-2393b96ccdbb.jpeg",
     "97": "https://image.tmdb.org/t/p/original/dgPueyEdOwpQ10fjuhL2WYFQwQs.jpg",
     "119": "https://image.tmdb.org/t/p/original/68MNrwlkpF7WnmNPXLah69CR5cb.jpg",
+    "0": "https://blog.kakaocdn.net/dn/beMRoh/btqJUNc2uBT/gLb6LDCKEemdV8IEki0St0/img.png",
 }
 
 for key in watch_providers:

--- a/src/back-end/web/data.json
+++ b/src/back-end/web/data.json
@@ -22,7 +22,7 @@
   {
     "fields": {
       "link": "https://watcha.com/",
-      "logo_key": "https://image.tmdb.org/t/p/original/cNi4Nv5EPsnvf5WmgwhfWDsdMUd.jpg",
+      "logo_key": "https://oopy.lazyrockets.com/api/rest/cdn/image/99453fde-4624-457f-8471-2393b96ccdbb.jpeg",
       "name": "WC",
       "tmdb_id": 97
     },


### PR DESCRIPTION

# 개요
- 왓챠 로고 데이터 변경해서 저장, DB저장시에 video_provider 구조 변경된 것과 맞게 수정

# 세부사항
- data.json : 왓챠 로고부분만 수정
- saving_db: 기존의 다대 다 관계 -> 1대 다 관계에 맞게 저장 로직 변경
- setting_provider: 라프텔 데이터 저장 + 왓챠 로고 바뀐 값으로 변경

# 참고
- 별로 고친거 없습니다 쓲쓲

# PR
- @dadahee 


# Related Issue

- Resolve #273